### PR TITLE
F scaling

### DIFF
--- a/bucky/model.py
+++ b/bucky/model.py
@@ -492,14 +492,14 @@ class SEIR_covid:
             self.params.H = xp.clip(H_fac * self.params.H * adm2_hosp_frac[None, :], self.params.F, 1.0)
 
             # TODO this .85 should be in param file...
-            self.params["F_eff"] = xp.clip(0.7 * self.params["F"] / self.params["H"], 0.0, 1.0)
+            self.params["F_eff"] = xp.clip(self.params.scaling_F * self.params["F"] / self.params["H"], 0.0, 1.0)
 
             yy.I = (1.0 - self.params.H) * I_init / yy.Im
             # y[Ici] = ic_frac * self.params.H * I_init / (len(Ici))
             # y[Rhi] = hosp_frac * self.params.H * I_init / (Rhn)
             yy.Ic = self.params.CASE_REPORT * self.params.H * I_init / yy.Im
             yy.Rh = (
-                0.7
+                self.params.scaling_F
                 * self.params.CASE_REPORT
                 * self.params.H
                 * I_init

--- a/par/scenario_5.yml
+++ b/par/scenario_5.yml
@@ -11,6 +11,8 @@ consts:
   case_reporting_min_deaths: 100.
   case_reporting_N_historical_days: 14
 
+  scaling_F: 0.7
+
 Tg:
   # Mean generation interval
   mean: 7.


### PR DESCRIPTION
Make the scaling of F easier tunable by adding it as a parameter to the parameterization file.
Scaling of F is used to make the initialization of deaths line up with historical deaths